### PR TITLE
Allow extra volumes, volumeMounts, and initContainers

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -554,7 +554,9 @@ The following table lists the configurable parameters of the opendistro elastics
 | `elasticsearch.configDirectory`                           | Location of elasticsearch configuration                                                                                                                  | `"/usr/share/elasticsearch/config"`                                     |
 | `elasticsearch.maxMapCount`                               | elasticsearch max_map_count                                                                                                                              | `262144`                                                                |
 | `elasticsearch.extraEnvs`                                 | Extra environments variables to be passed to elasticsearch services                                                                                      | `[]`                                                                    |
-
+| `elasticsearch.extraVolumes`                              | Array of extra volumes to be added                                                                                                                       | `[]`                                                                    |
+| `elasticsearch.extraVolumeMounts`                         | Array of extra volume mounts to be added                                                                                                                 | `[]`                                                                    |
+| `elasticsearch.extraInitContainers`                       | Array of extra init containers                                                                                                                           | `[]`                                                                    |
 
 ## Acknowledgements
 * [Kalvin Chau](https://github.com/kalvinnchau) (Software Engineer - Viasat) for all his help with the Kubernetes internals, certs, and debugging

--- a/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-client-deploy.yaml
@@ -65,6 +65,9 @@ spec:
         - vm.max_map_count={{ .Values.elasticsearch.maxMapCount }}
         securityContext:
           privileged: true
+{{- if .Values.elasticsearch.extraInitContainers }}
+{{ toYaml .Values.elasticsearch.extraInitContainers| indent 6 }}
+{{- end }}
       containers:
       - name: elasticsearch
         env:
@@ -164,6 +167,9 @@ spec:
           name: admin-certs
           subPath: admin-root-ca.pem
         {{- end }}
+{{- if .Values.elasticsearch.extraVolumeMounts }}
+{{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
+{{- end }}
       volumes:
       - name: config
         secret:
@@ -183,4 +189,7 @@ spec:
         secret:
           secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
       {{- end }}
+{{- if .Values.elasticsearch.extraVolumes }}
+{{ toYaml .Values.elasticsearch.extraVolumes | indent 6 }}
+{{- end }}
 {{- end }}

--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -70,6 +70,9 @@ spec:
           - mountPath: /usr/share/elasticsearch/data
             name: data
             subPath: {{ .Values.elasticsearch.data.persistence.subPath }}
+{{- if .Values.elasticsearch.extraInitContainers }}
+{{ toYaml .Values.elasticsearch.extraInitContainers| indent 6 }}
+{{- end }}
     {{- with .Values.elasticsearch.data.affinity }}
       affinity:
 {{ toYaml . | indent 8 }}
@@ -174,6 +177,9 @@ spec:
           name: admin-certs
           subPath: admin-root-ca.pem
          {{- end }}
+{{- if .Values.elasticsearch.extraVolumeMounts }}
+{{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
+{{- end }}
       volumes:
       - name: config
         secret:
@@ -203,6 +209,9 @@ spec:
           claimName: {{ .Values.elasticsearch.data.persistence.existingClaim }}
       {{- end }}
       {{- end }}
+{{- if .Values.elasticsearch.extraVolumes }}
+{{ toYaml .Values.elasticsearch.extraVolumes | indent 6 }}
+{{- end }}
   {{- if and .Values.elasticsearch.data.persistence.enabled (not .Values.elasticsearch.data.persistence.existingClaim) }}
   volumeClaimTemplates:
   - metadata:

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -75,6 +75,9 @@ spec:
           - mountPath: /usr/share/elasticsearch/data
             name: data
             subPath: {{ .Values.elasticsearch.master.persistence.subPath }}
+{{- if .Values.elasticsearch.extraInitContainers }}
+{{ toYaml .Values.elasticsearch.extraInitContainers| indent 6 }}
+{{- end }}
       containers:
       - name: elasticsearch
         env:
@@ -218,6 +221,9 @@ spec:
           name: tenants
           subPath: tenants.yml
         {{- end }}
+{{- if .Values.elasticsearch.extraVolumeMounts }}
+{{ toYaml .Values.elasticsearch.extraVolumeMounts | indent 8 }}
+{{- end }}
       {{- end }}
       volumes:
       - name: config
@@ -278,6 +284,9 @@ spec:
           claimName: {{ .Values.elasticsearch.master.persistence.existingClaim }}
       {{- end }}
       {{- end }}
+{{- if .Values.elasticsearch.extraVolumes }}
+{{ toYaml .Values.elasticsearch.extraVolumes | indent 6 }}
+{{- end }}
   {{- if and .Values.elasticsearch.master.persistence.enabled (not .Values.elasticsearch.master.persistence.existingClaim) }}
   volumeClaimTemplates:
   - metadata:

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -137,6 +137,20 @@ elasticsearch:
 
   extraEnvs: []
 
+  extraInitContainers: []
+  # - name: do-something
+  #   image: busybox
+  #   command: ['do', 'something']
+
+  extraVolumes: []
+  # - name: extras
+  #   emptyDir: {}
+
+  extraVolumeMounts: []
+  # - name: extras
+  #   mountPath: /usr/share/extras
+  #   readOnly: true
+
   initContainer:
     image: busybox
     imageTag: 1.27.2


### PR DESCRIPTION
This commit adds the option for one to specifiy extra volumes, volumesMounts, and initContainers for the elasticsearch pods. 

Should perhaps not be merged to master yet but i want this up for review :) 