### PR TITLE
S3 credentials secrets

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-s3-credentials-secret.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-s3-credentials-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.elasticsearch.s3.enabled (not .Values.elasticsearch.s3.useExistingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.elasticsearch.s3.secretName }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+stringData:
+  s3.client.default.access_key: {{ .Values.elasticsearch.s3.accessKey }}
+  s3.client.default.secret_key: {{ .Values.elasticsearch.s3.secretKey }}
+{{- end }}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -174,6 +174,12 @@ elasticsearch:
       # rolesMapping.yml: |-
       # tenants.yml: |-
 
+  s3:
+    enabled: false
+    useExistingSecret: true
+    accessKey:
+    secretKey:
+
   extraEnvs: []
 
   extraInitContainers: []


### PR DESCRIPTION
This commit adds the ability to create a secrets that should be loaded into the secure settings.
We need to be able to store the credentials for s3 since we want to store snapshots there

Example usage
```
elasticsearch:
  s3:
    enabled: true
    useExistingSecret: false
    secretName: opendistro-es-s3-credentials
    accessKey: {{ requiredEnv "S3_ACCESS_KEY" }}
    secretKey: {{ requiredEnv "S3_SECRET_KEY" }}
```