### PR TITLE
External users

### DIFF
--- a/helm/opendistro-es/templates/configurer/configurer-config.yml
+++ b/helm/opendistro-es/templates/configurer/configurer-config.yml
@@ -1,6 +1,6 @@
 {{- if .Values.configurer.enabled }}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-configurer-config
   labels:
@@ -9,7 +9,8 @@ metadata:
     "helm.sh/hook": {{ .Values.configurer.helm.hook }}
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": {{ .Values.configurer.helm.deletePolicy }}
-data:
+type: Opaque
+stringData:
   configurer.sh: |-
 {{ tpl (.Files.Get "files/configurer/configurer.sh") . | indent 4 }}
 

--- a/helm/opendistro-es/templates/configurer/configurer.yaml
+++ b/helm/opendistro-es/templates/configurer/configurer.yaml
@@ -8,7 +8,7 @@ metadata:
 {{ include "opendistro-es.labels.standard" . | indent 4 }}
   annotations:
     "helm.sh/hook": {{ .Values.configurer.helm.hook }}
-    # Use higher value so that the configmap is created before this job
+    # Use higher value so that the secret is created before this job
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": {{ .Values.configurer.helm.deletePolicy }}
 spec:
@@ -53,6 +53,6 @@ spec:
         {{- end }}     
       volumes:
       - name: files
-        configMap:
-          name: {{ template "opendistro-es.fullname" . }}-configurer-config
+        secret:
+          secretName: {{ template "opendistro-es.fullname" . }}-configurer-config
 {{- end }}

--- a/helm/opendistro-es/templates/curator/curator.yaml
+++ b/helm/opendistro-es/templates/curator/curator.yaml
@@ -38,12 +38,12 @@ spec:
               - name: ES_USERNAME
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.kibana.elasticsearchAccount.secret }}
+                    name: {{ .Values.curator.elasticsearchAccount.secret }}
                     key: username
               - name: ES_PASSWORD
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.kibana.elasticsearchAccount.secret }}
+                    name: {{ .Values.curator.elasticsearchAccount.secret }}
                     key: password
               - name: ES_AUTH
                 value: $(ES_USERNAME):$(ES_PASSWORD)

--- a/helm/opendistro-es/templates/curator/es-account-secret.yaml
+++ b/helm/opendistro-es/templates/curator/es-account-secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.curator.elasticsearchAccount.useExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.curator.elasticsearchAccount.secret }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+    username: {{  .Values.curator.elasticsearchAccount.username | b64enc }}
+    password: {{  .Values.curator.elasticsearchAccount.password | b64enc }}
+{{- end }}

--- a/helm/opendistro-es/templates/metrics_exporter/es-account-secret.yaml
+++ b/helm/opendistro-es/templates/metrics_exporter/es-account-secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.curator.elasticsearchAccount.useExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.metricsExporter.elasticsearchAccount.secret }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+    username: {{  .Values.metricsExporter.elasticsearchAccount.username | b64enc }}
+    password: {{  .Values.metricsExporter.elasticsearchAccount.password | b64enc }}
+{{- end }}

--- a/helm/opendistro-es/templates/slm/es-account-secret.yaml
+++ b/helm/opendistro-es/templates/slm/es-account-secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.slm.elasticsearchAccount.useExistingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.slm.elasticsearchAccount.secret }}
+  labels:
+{{ include "opendistro-es.labels.standard" . | indent 4 }}
+type: Opaque
+data:
+    username: {{  .Values.slm.elasticsearchAccount.username | b64enc }}
+    password: {{  .Values.slm.elasticsearchAccount.password | b64enc }}
+{{- end }}

--- a/helm/opendistro-es/values.yaml
+++ b/helm/opendistro-es/values.yaml
@@ -167,6 +167,7 @@ elasticsearch:
   securityConfig:
     enabled: true
     path: "/usr/share/elasticsearch/plugins/opendistro_security/securityconfig"
+
     config: {}
       # config.yml: |-
       # internal_users.yml: |-
@@ -597,6 +598,47 @@ configurer:
     hook: post-install,post-upgrade
     deletePolicy: before-hook-creation,hook-failed
 
+  elasticsearchAccount:
+    useExistingSecret: true
+    username:
+    password:
+    secret: ""
+    keyPassphrase:
+      enabled: false
+
+  # Allow specification of security plugin users,
+  # roles, and role mappings.
+  securityPlugin:
+    # Users to create
+    users:
+    # - username: your_user
+    #   definition:
+    #     password: your_password
+
+    # Roles to create
+    roles:
+    # - role_name: simple_monitor
+    #   definition:
+    #     cluster_permissions:
+    #     - "cluster:monitor/main"
+
+    # Role mappings to create
+    roles_mapping:
+    # - mapping_name: simple_monitor
+    #   definition:
+    #     users:
+    #     - your_user
+
+metricsExporter:
+  elasticsearchAccount:
+    useExistingSecret: true
+    username:
+    password:
+    secret: ""
+    keyPassphrase:
+      enabled: false
+
+slm:
   elasticsearchAccount:
     useExistingSecret: true
     username:


### PR DESCRIPTION
Based on our discussion I have created the external users (fluentd, curator, snapshotter and exporter) and their roles.  The script is generic enough to add any user and their roles and mappings. I have added a complete configurations for fluentd and snapshotter as an example in the values.yaml file.

This pr fixes https://github.com/elastisys/ck8s/issues/513
The script is built on top of what @danielharr did  for configurer

Note to the reviewers: once the part under `configurer.sh` is approved the different blocks in the `values.yaml` file will go to https://github.com/elastisys/ck8s/tree/opendistro.  As such the focus in this review should mainly be on  `configurer.sh` while keeping an eye on the values.yaml section.