### PR TITLE
Set UID for curator

### DIFF
--- a/helm/opendistro-es/templates/curator/curator.yaml
+++ b/helm/opendistro-es/templates/curator/curator.yaml
@@ -57,4 +57,6 @@ spec:
             - name: curator-config
               configMap:
                 name: {{ template "opendistro-es.fullname" . }}-curator-config
+          securityContext:
+            runAsUser: 65534
 {{- end  }}


### PR DESCRIPTION
After some cleanup in ck8s i found out that the curator continer runs as `nobody:nobody` which does not work with PSPs since they only deal with UIDs. This commit adds nobody's UID in the security context.
