### PR TITLE
Update cert-manager resources to v1

### DIFF
--- a/helm/opendistro-es/templates/certmanager/ca-certificate.yaml
+++ b/helm/opendistro-es/templates/certmanager/ca-certificate.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.certmanager.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-ca
@@ -8,19 +8,21 @@ metadata:
 spec:
   secretName: {{ template "opendistro-es.fullname" . }}-ca-cert
   duration: {{ .Values.certmanager.ca.duration }}
-  keySize: {{ .Values.certmanager.ca.keySize }}
   renewBefore: {{ .Values.certmanager.ca.renewBefore }}
-  keyAlgorithm: rsa
-  keyEncoding: pkcs8
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: {{ .Values.certmanager.ca.keySize }}
   isCA: true
   commonName: {{ .Values.certmanager.ca.commonName }}
   usages:
 {{- if .Values.certmanager.ca.usages }}
 {{ toYaml .Values.certmanager.ca.usages| indent 2 }}
 {{- end }}
-  organization:
+  subject:
+    organizations:
 {{- if .Values.certmanager.ca.organization }}
-{{ toYaml .Values.certmanager.ca.organization| indent 2 }}
+{{ toYaml .Values.certmanager.ca.organization| indent 4 }}
 {{- end }}
   issuerRef:
     name: {{ template "opendistro-es.fullname" . }}-selfsigned

--- a/helm/opendistro-es/templates/certmanager/certificates.yaml
+++ b/helm/opendistro-es/templates/certmanager/certificates.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.certmanager.enabled }}
 {{- if .Values.certmanager.elasticsearch.transport.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-transport
@@ -9,18 +9,20 @@ metadata:
 spec:
   secretName: {{ .Values.elasticsearch.ssl.transport.existingCertSecret }}
   duration: {{ .Values.certmanager.elasticsearch.transport.duration }}
-  keySize: {{ .Values.certmanager.elasticsearch.transport.keySize }}
-  keyAlgorithm: rsa
-  keyEncoding: pkcs8
+  privateKey:
+    size: {{ .Values.certmanager.elasticsearch.transport.keySize }}
+    algorithm: RSA
+    encoding: PKCS8
   renewBefore: {{ .Values.certmanager.elasticsearch.transport.renewBefore }}
   usages:
 {{- if .Values.certmanager.elasticsearch.transport.usages }}
 {{ toYaml .Values.certmanager.elasticsearch.transport.usages| indent 2 }}
 {{- end }}
   commonName: {{ .Values.certmanager.elasticsearch.transport.commonName }}
-  organization:
+  subject:
+    organizations:
 {{- if .Values.certmanager.elasticsearch.transport.organization }}
-{{ toYaml .Values.certmanager.elasticsearch.transport.organization| indent 2 }}
+{{ toYaml .Values.certmanager.elasticsearch.transport.organization| indent 4 }}
 {{- end }}
   issuerRef:
     name: {{ template "opendistro-es.fullname" . }}-ca
@@ -28,7 +30,7 @@ spec:
 {{-  end }}
 {{- if .Values.certmanager.elasticsearch.admin.enabled }}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-admin
@@ -37,18 +39,20 @@ metadata:
 spec:
   secretName: {{ .Values.elasticsearch.ssl.admin.existingCertSecret }}
   duration: {{ .Values.certmanager.elasticsearch.admin.duration }}
-  keySize: {{ .Values.certmanager.elasticsearch.admin.keySize }}
-  keyAlgorithm: rsa
-  keyEncoding: pkcs8
+  privateKey:
+    size: {{ .Values.certmanager.elasticsearch.admin.keySize }}
+    algorithm: RSA
+    encoding: PKCS8
   renewBefore: {{ .Values.certmanager.elasticsearch.admin.renewBefore }}
   usages:
 {{- if .Values.certmanager.elasticsearch.admin.usages }}
 {{ toYaml .Values.certmanager.elasticsearch.admin.usages| indent 2 }}
 {{- end }}
   commonName: {{ .Values.certmanager.elasticsearch.admin.commonName }}
-  organization:
+  subject:
+    organizations:
 {{- if .Values.certmanager.elasticsearch.admin.organization }}
-{{ toYaml .Values.certmanager.elasticsearch.admin.organization| indent 2 }}
+{{ toYaml .Values.certmanager.elasticsearch.admin.organization| indent 4 }}
 {{- end }}
   issuerRef:
     name: {{ template "opendistro-es.fullname" . }}-ca

--- a/helm/opendistro-es/templates/certmanager/issuers.yaml
+++ b/helm/opendistro-es/templates/certmanager/issuers.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.certmanager.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-ca
@@ -10,7 +10,7 @@ spec:
     secretName: {{ template "opendistro-es.fullname" . }}-ca-cert
 ---
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "opendistro-es.fullname" . }}-selfsigned


### PR DESCRIPTION
*Description of changes:*
In ck8s we have now the v1 API of cert-manager and this commit updates the resources in this repo to comply with v1.

*Test Results:*

**Note: If this PR is related to Helm, please also update the README for related documentation changes. Thanks.**
**https://github.com/opendistro-for-elasticsearch/opendistro-build/blob/master/helm/README.md**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
